### PR TITLE
Add ability to read font from reader

### DIFF
--- a/figure.go
+++ b/figure.go
@@ -3,6 +3,7 @@ package figure
 import (
   "log"
   "strings"
+  "io"
 )
 
 const ascii_offset = 32
@@ -17,6 +18,14 @@ type figure struct {
 
 func NewFigure(phrase, fontName string, strict bool) figure {
   font := newFont(fontName)
+  if font.reverse {
+    phrase = reverse(phrase)
+  }
+  return figure{phrase, font, strict}
+}
+
+func NewFigureWithFont(phrase string, reader io.Reader, strict bool) figure {
+  font := newFontFromReader(reader)
   if font.reverse {
     phrase = reverse(phrase)
   }

--- a/font.go
+++ b/font.go
@@ -28,7 +28,6 @@ func newFont(name string) (font font) {
 }
 
 func newFontFromReader(reader io.Reader) (font font) {
-  font.setName("")
   scanner := bufio.NewScanner(reader)
   font.setAttributes(scanner)
   font.setLetters(scanner)

--- a/font.go
+++ b/font.go
@@ -3,6 +3,7 @@ package figure
 import (
   "bufio"
   "strings"
+  "io"
 )
 
 const defaultFont = "standard"
@@ -21,6 +22,14 @@ func newFont(name string) (font font) {
   file := getFile(font.name)
   defer file.Close()
   scanner := bufio.NewScanner(file)
+  font.setAttributes(scanner)
+  font.setLetters(scanner)
+  return font
+}
+
+func newFontFromReader(reader io.Reader) (font font) {
+  font.setName("")
+  scanner := bufio.NewScanner(reader)
   font.setAttributes(scanner)
   font.setLetters(scanner)
   return font


### PR DESCRIPTION
Now io.Reader can be passed instead of font name while creating new Figure.